### PR TITLE
MNT: Remove glob, json from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 # List required packages in this file, one per line.
-json
-glob
 numpy
 pandas
 seaborn


### PR DESCRIPTION
The modules are part of the standard library and come directly with Python.
Keeping them as a requirement will lead to installation failures with pip, as
there is not version of glob or json available on pypi